### PR TITLE
Added Locked Status info on Dashboard widget and Backups Logs menu

### DIFF
--- a/app/Http/Controllers/BackupLogController.php
+++ b/app/Http/Controllers/BackupLogController.php
@@ -56,6 +56,11 @@ class BackupLogController extends Controller
             $query->whereDate('created_at', '<=', $request->get('date_to'));
         }
 
+        // Filter by locked status
+        if ($request->filled('locked')) {
+            $query->where('locked', $request->get('locked'));
+        }
+
         // Sorting
         $sortBy = $request->get('sort', 'created_at');
         $sortDirection = $request->get('direction', 'desc');

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -43,6 +43,7 @@ class DashboardController extends Controller
                 'created_at' => $log->created_at,
                 'is_file_available' => $log->isFileAvailable(),
                 'data_source' => $log->dataSource,
+                'locked' => $log->locked,
             ]);
     }
 

--- a/resources/js/Pages/BackupLogs/Index.tsx
+++ b/resources/js/Pages/BackupLogs/Index.tsx
@@ -110,6 +110,14 @@ export default function BackupLogsIndex({backupLogs, dataSources}: Props) {
                                 transformVariant: (_value: any, row: BackupLog) => getFileStatusVariant(row),
                             },
                             {
+                                label: "Locked",
+                                name: "locked",
+                                type: "badge",
+                                sortable: false,
+                                transform: (value: boolean) => (value ? 'Locked' : 'Unlocked'),
+                                transformVariant: (value: boolean) => (value ? 'default' : 'secondary'),
+                            },
+                            {
                                 label: "Created",
                                 name: "created_at",
                                 type: "text",
@@ -155,6 +163,15 @@ export default function BackupLogsIndex({backupLogs, dataSources}: Props) {
                                 options: [
                                     {label: "Manual", value: "Manual"},
                                     {label: "Automated", value: "Automated"},
+                                ]
+                            },
+                            {
+                                type: 'select',
+                                identifier: 'locked',
+                                label: 'Locked',
+                                options: [
+                                    {label: "Unlocked", value: 0},
+                                    {label: "Locked", value: 1},
                                 ]
                             },
                         ]}

--- a/resources/js/Pages/Dashboard.tsx
+++ b/resources/js/Pages/Dashboard.tsx
@@ -141,6 +141,12 @@ export default function Dashboard({stats, recentBackups, activeDataSources}: App
                                                         >
                                                             {backup.status}
                                                         </Badge>
+                                                        <Badge
+                                                            className="text-xs"
+                                                            variant={backup.locked ? 'default' : 'secondary'}
+                                                        >
+                                                            {backup.locked ? 'Locked' : 'Unlocked'}
+                                                        </Badge>
                                                         <span className={'font-mono'}>
                                                             {(() => {
                                                                 if (!backup.is_file_available) {

--- a/resources/js/Pages/Dashboard.tsx
+++ b/resources/js/Pages/Dashboard.tsx
@@ -1,4 +1,4 @@
-import {Head, router} from '@inertiajs/react';
+import {Head, Link, router} from '@inertiajs/react';
 import {Activity, ArrowUpRight, CreditCard, HardDrive, Users} from 'lucide-react';
 import {useEffect} from 'react';
 
@@ -11,7 +11,7 @@ import {Table, TableBody, TableCell, TableHead, TableHeader, TableRow} from '@/c
 import {DataSource} from "@/types/datasource";
 import {triggerBackup} from "@/components/functions/backups";
 import {App} from "@/types/dashboard";
-import { format } from 'date-fns';
+import {format} from 'date-fns';
 
 export default function Dashboard({stats, recentBackups, activeDataSources}: App.Dashboard.PageProps) {
     useEffect(() => {
@@ -115,11 +115,16 @@ export default function Dashboard({stats, recentBackups, activeDataSources}: App
                                         {recentBackups.map((backup) => (
                                             <TableRow key={backup.id}>
                                                 <TableCell>
-                                                    <div
-                                                        className="font-medium">{backup.data_source?.name}</div>
+                                                    <Link
+                                                        href={route('backup-logs.show', backup.id)}
+                                                        className="font-medium hover:underline"
+                                                    >
+                                                        {backup.data_source?.name}
+                                                    </Link>
                                                 </TableCell>
                                                 <TableCell className="text-left">
-                                                    <div className="hidden text-sm text-muted-foreground md:flex md:gap-2 md:items-center">
+                                                    <div
+                                                        className="hidden text-sm text-muted-foreground md:flex md:gap-2 md:items-center">
                                                         <Badge
                                                             className="text-xs"
                                                             variant={backup.type === 'Manual' ? 'default' : 'secondary'}
@@ -137,7 +142,7 @@ export default function Dashboard({stats, recentBackups, activeDataSources}: App
                                                             {backup.status}
                                                         </Badge>
                                                         <span className={'font-mono'}>
-                                                            {(()=>{
+                                                            {(() => {
                                                                 if (!backup.is_file_available) {
                                                                     if (backup.status === 'Completed') {
                                                                         return 'Deleted';
@@ -155,7 +160,8 @@ export default function Dashboard({stats, recentBackups, activeDataSources}: App
                                                         </span>
                                                     </div>
                                                 </TableCell>
-                                                <TableCell className="text-right">{format(new Date(backup.created_at as string), "dd LLL y HH:mm:ss")}</TableCell>
+                                                <TableCell
+                                                    className="text-right">{format(new Date(backup.created_at as string), "dd LLL y HH:mm:ss")}</TableCell>
                                             </TableRow>
                                         ))}
                                     </TableBody>


### PR DESCRIPTION
Changes:
- Added Locked Status Info on dashboard Recent Backup widget
- Added clickable link to recent backups on Dashboard to redirect to show log detail page
- Added Locked Status filter and column on Backup Logs menu
Please check, thank you